### PR TITLE
Move configuration for rapid pro -> pipeline key remapping to configuration json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,5 @@ RUN mkdir /data
 # Copy the rest of the project
 ADD code_schemes/*.json /app/code_schemes/
 ADD src /app/src
+ADD pipeline_config.json /app
 ADD pipeline.py /app

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -80,7 +80,7 @@ CMD="
     $GSUTIL_CP_CMD \
 
     pipenv run $PROFILE_CPU_CMD python -u pipeline.py $DRIVE_UPLOAD_ARG \
-    \"$USER\" /data/phone-number-uuid-table-input.json \
+    \"$USER\" pipeline_config.json /data/phone-number-uuid-table-input.json \
     /data/s02e01-input.json /data/s02e02-input.json /data/s02e03-input.json \
     /data/s02e04-input.json /data/s02e05-input.json /data/s02e06-input.json \
     /data/s01-demog-input.json /data/s02-demog-input.json /data/prev-coded \

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import random
 
 from core_data_modules.traced_data.io import TracedDataJsonIO
 from core_data_modules.util import PhoneNumberUuidTable, IOUtils
@@ -9,6 +10,7 @@ from src import CombineRawDatasets
 from src.analysis_file import AnalysisFile
 from src.apply_manual_codes import ApplyManualCodes
 from src.auto_code_show_messages import AutoCodeShowMessages
+from src.lib import PipelineConfiguration
 from src.lib.auto_code_surveys import AutoCodeSurveys
 from src.production_file import ProductionFile
 from src.translate_rapid_pro_keys import TranslateRapidProKeys
@@ -31,6 +33,8 @@ if __name__ == "__main__":
                              "upload the production CSV to"),
 
     parser.add_argument("user", help="User launching this program")
+    parser.add_argument("pipeline_configuration_file_path", metavar="pipeline-configuration-file",
+                        help="Path to the pipeline configuration json file"),
 
     parser.add_argument("phone_number_uuid_table_path", metavar="phone-number-uuid-table-path",
                         help="JSON file containing the phone number <-> UUID lookup table for the messages/surveys "
@@ -94,6 +98,7 @@ if __name__ == "__main__":
         production_csv_drive_path = args.drive_upload[3]
 
     user = args.user
+    pipeline_configuration_file_path = args.pipeline_configuration_file_path
 
     phone_number_uuid_table_path = args.phone_number_uuid_table_path
     s02e01_input_path = args.s02e01_input_path
@@ -115,6 +120,11 @@ if __name__ == "__main__":
 
     message_paths = [s02e01_input_path, s02e02_input_path, s02e03_input_path,
                      s02e04_input_path, s02e05_input_path, s02e06_input_path]
+
+    # Load the pipeline configuration file
+    print("Loading Pipeline Configuration File...")
+    with open(pipeline_configuration_file_path) as f:
+        pipeline_configuration = PipelineConfiguration.from_configuration_file(f)
 
     # Load phone number <-> UUID table
     print("Loading Phone Number <-> UUID Table...")
@@ -142,7 +152,7 @@ if __name__ == "__main__":
     data = CombineRawDatasets.combine_raw_datasets(user, messages_datasets, [s01_demographics, s02_demographics])
 
     print("Translating Rapid Pro Keys...")
-    data = TranslateRapidProKeys.translate_rapid_pro_keys(user, data, prev_coded_dir_path)
+    data = TranslateRapidProKeys.translate_rapid_pro_keys(user, data, pipeline_configuration, prev_coded_dir_path)
 
     print("Auto Coding Messages...")
     data = AutoCodeShowMessages.auto_code_show_messages(user, data, icr_output_dir, coded_dir_path)

--- a/pipeline_config.json
+++ b/pipeline_config.json
@@ -1,4 +1,47 @@
 {
   "RapidProBaseURL": "https://textit.in",
-  "RapidProTokenFileURL": "gs://avf-credentials/csap-text-it-token.txt"
+  "RapidProTokenFileURL": "gs://avf-credentials/csap-text-it-token.txt",
+  "RapidProKeyRemappings": [
+    {"RapidProKey": "avf_phone_id", "PipelineKey": "uid"},
+
+    {"RapidProKey": "Rqa_S02E01 (Run ID) - csap_s02e01_activation", "PipelineKey": "rqa_s02_e01_run_id"},
+    {"RapidProKey": "Rqa_S02E02 (Run ID) - csap_s02e02_activation", "PipelineKey": "rqa_s02e02_run_id"},
+    {"RapidProKey": "Rqa_S02E03 (Run ID) - csap_s02e03_activation", "PipelineKey": "rqa_s02e03_run_id"},
+    {"RapidProKey": "Rqa_S02E04 (Run ID) - csap_s02e04_activation", "PipelineKey": "rqa_s02e04_run_id"},
+    {"RapidProKey": "Rqa_S02E05 (Run ID) - csap_s02e05_activation", "PipelineKey": "rqa_s02e05_run_id"},
+    {"RapidProKey": "Rqa_S02E06 (Run ID) - csap_s02e06_activation", "PipelineKey": "rqa_s02e06_run_id"},
+
+    {"RapidProKey": "Rqa_S02E01 (Time) - csap_s02e01_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_S02E02 (Time) - csap_s02e02_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_S02E03 (Time) - csap_s02e03_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_S02E04 (Time) - csap_s02e04_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_S02E05 (Time) - csap_s02e05_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_S02E06 (Time) - csap_s02e06_activation", "PipelineKey": "sent_on"},
+
+    {"RapidProKey": "Gender (Value) - csap_demog", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Gender (Time) - csap_demog", "PipelineKey": "gender_time"},
+    {"RapidProKey": "Mog_Sub_District (Value) - csap_demog", "PipelineKey": "location_raw"},
+    {"RapidProKey": "Mog_Sub_District (Time) - csap_demog", "PipelineKey": "location_time"},
+    {"RapidProKey": "Age (Value) - csap_demog", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Age (Time) - csap_demog", "PipelineKey": "age_time"},
+    {"RapidProKey": "Idp_Camp (Value) - csap_demog", "PipelineKey": "idp_camp_raw"},
+    {"RapidProKey": "Idp_Camp (Time) - csap_demog", "PipelineKey": "idp_camp_time"},
+    {"RapidProKey": "Recently_Displaced (Value) - csap_demog", "PipelineKey": "recently_displaced_raw"},
+    {"RapidProKey": "Recently_Displaced (Time) - csap_demog", "PipelineKey": "recently_displaced_time"},
+    {"RapidProKey": "Hh_Language (Value) - csap_demog", "PipelineKey": "household_language_raw"},
+    {"RapidProKey": "Hh_Language (Time) - csap_demog", "PipelineKey": "household_language_time"},
+
+    {"RapidProKey": "Gender (Value) - csap_s02_demog", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Gender (Time) - csap_s02_demog", "PipelineKey": "gender_time"},
+    {"RapidProKey": "District (Value) - csap_s02_demog", "PipelineKey": "location_raw"},
+    {"RapidProKey": "District (Time) - csap_s02_demog", "PipelineKey": "location_time"},
+    {"RapidProKey": "Age (Value) - csap_s02_demog", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Age (Time) - csap_s02_demog", "PipelineKey": "age_time"},
+    {"RapidProKey": "Idp_Camp (Value) - csap_s02_demog", "PipelineKey": "idp_camp_raw"},
+    {"RapidProKey": "Idp_Camp (Time) - csap_s02_demog", "PipelineKey": "idp_camp_time"},
+    {"RapidProKey": "Recently_Displaced (Value) - csap_s02_demog", "PipelineKey": "recently_displaced_raw"},
+    {"RapidProKey": "Recently_Displaced (Time) - csap_s02_demog", "PipelineKey": "recently_displaced_time"},
+    {"RapidProKey": "Hh_Language (Value) - csap_s02_demog", "PipelineKey": "household_language_raw"},
+    {"RapidProKey": "Hh_Language (Time) - csap_s02_demog", "PipelineKey": "household_language_time"}
+  ]
 }

--- a/pipeline_config.json
+++ b/pipeline_config.json
@@ -4,7 +4,7 @@
   "RapidProKeyRemappings": [
     {"RapidProKey": "avf_phone_id", "PipelineKey": "uid"},
 
-    {"RapidProKey": "Rqa_S02E01 (Run ID) - csap_s02e01_activation", "PipelineKey": "rqa_s02_e01_run_id"},
+    {"RapidProKey": "Rqa_S02E01 (Run ID) - csap_s02e01_activation", "PipelineKey": "rqa_s02e01_run_id"},
     {"RapidProKey": "Rqa_S02E02 (Run ID) - csap_s02e02_activation", "PipelineKey": "rqa_s02e02_run_id"},
     {"RapidProKey": "Rqa_S02E03 (Run ID) - csap_s02e03_activation", "PipelineKey": "rqa_s02e03_run_id"},
     {"RapidProKey": "Rqa_S02E04 (Run ID) - csap_s02e04_activation", "PipelineKey": "rqa_s02e04_run_id"},

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -1,7 +1,7 @@
 import json
 
 from core_data_modules.cleaners import somali, Codes
-from core_data_modules.data_models import Scheme
+from core_data_modules.data_models import Scheme, validators
 from dateutil.parser import isoparse
 
 
@@ -242,3 +242,69 @@ class PipelineConfiguration(object):
         #            cleaner=somali.DemographicCleaner.clean_yes_no,
         #            code_scheme=None)  # TODO
     ])
+
+    def __init__(self, rapid_pro_base_url, rapid_pro_token_file_url, rapid_pro_key_remappings):
+        """
+        :param rapid_pro_base_url: URL of the Rapid Pro server to download data from.
+        :type rapid_pro_base_url: str
+        :param rapid_pro_token_file_url: GS URL of a text file containing the authorisation token for the Rapid Pro
+                                         server.
+        :type rapid_pro_token_file_url: str
+        :param rapid_pro_key_remappings: List of rapid_pro_key -> pipeline_key remappings.
+        :type rapid_pro_key_remappings: list of RapidProKeyRemapping
+        """
+        self.rapid_pro_base_url = rapid_pro_base_url
+        self.rapid_pro_token_file_url = rapid_pro_token_file_url
+        self.rapid_pro_key_remappings = rapid_pro_key_remappings
+        
+        self.validate()
+
+    @classmethod
+    def from_configuration_dict(cls, configuration_dict):
+        rapid_pro_base_url = configuration_dict["RapidProBaseURL"]
+        rapid_pro_token_file_url = configuration_dict["RapidProTokenFileURL"]
+
+        rapid_pro_key_remappings = []
+        for remapping_dict in configuration_dict["RapidProKeyRemappings"]:
+            rapid_pro_key_remappings.append(RapidProKeyRemapping.from_configuration_dict(remapping_dict))
+
+        return cls(rapid_pro_base_url, rapid_pro_token_file_url, rapid_pro_key_remappings)
+
+    @classmethod
+    def from_configuration_file(cls, f):
+        return cls.from_configuration_dict(json.load(f))
+    
+    def validate(self):
+        validators.validate_string(self.rapid_pro_base_url, "rapid_pro_base_url")
+        validators.validate_string(self.rapid_pro_token_file_url, "rapid_pro_token_file_url")
+
+        validators.validate_list(self.rapid_pro_key_remappings, "rapid_pro_key_remappings")
+        for i, remapping in enumerate(self.rapid_pro_key_remappings):
+            assert isinstance(remapping, RapidProKeyRemapping), \
+                f"self.rapid_pro_key_mappings[{i}] is not of type RapidProKeyRemapping"
+            remapping.validate()
+        
+
+class RapidProKeyRemapping(object):
+    def __init__(self, rapid_pro_key, pipeline_key):
+        """
+        :param rapid_pro_key: Name of key in the dataset exported via RapidProTools.
+        :type rapid_pro_key: str
+        :param pipeline_key: Name to use for that key in the rest of the pipeline.
+        :type pipeline_key: str
+        """
+        self.rapid_pro_key = rapid_pro_key
+        self.pipeline_key = pipeline_key
+        
+        self.validate()
+
+    @classmethod
+    def from_configuration_dict(cls, configuration_dict):
+        rapid_pro_key = configuration_dict["RapidProKey"]
+        pipeline_key = configuration_dict["PipelineKey"]
+        
+        return cls(rapid_pro_key, pipeline_key)
+    
+    def validate(self):
+        validators.validate_string(self.rapid_pro_key, "rapid_pro_key")
+        validators.validate_string(self.pipeline_key, "pipeline_key")

--- a/src/translate_rapid_pro_keys.py
+++ b/src/translate_rapid_pro_keys.py
@@ -4,56 +4,6 @@ from core_data_modules.util import TimeUtils
 
 class TranslateRapidProKeys(object):
     # TODO: Move the constants in this file to configuration json
-    RAPID_PRO_KEY_MAP = [
-        # List of (new_key, old_key)
-        ("uid", "avf_phone_id"),
-
-        ("rqa_s02e01_run_id", "Rqa_S02E01 (Run ID) - csap_s02e01_activation"),
-        ("rqa_s02e02_run_id", "Rqa_S02E02 (Run ID) - csap_s02e02_activation"),
-        ("rqa_s02e03_run_id", "Rqa_S02E03 (Run ID) - csap_s02e03_activation"),
-        ("rqa_s02e04_run_id", "Rqa_S02E04 (Run ID) - csap_s02e04_activation"),
-        ("rqa_s02e05_run_id", "Rqa_S02E05 (Run ID) - csap_s02e05_activation"),
-        ("rqa_s02e06_run_id", "Rqa_S02E06 (Run ID) - csap_s02e06_activation"),
-
-        ("sent_on", "Rqa_S02E01 (Time) - csap_s02e01_activation"),
-        ("sent_on", "Rqa_S02E02 (Time) - csap_s02e02_activation"),
-        ("sent_on", "Rqa_S02E03 (Time) - csap_s02e03_activation"),
-        ("sent_on", "Rqa_S02E04 (Time) - csap_s02e04_activation"),
-        ("sent_on", "Rqa_S02E05 (Time) - csap_s02e05_activation"),
-        ("sent_on", "Rqa_S02E06 (Time) - csap_s02e06_activation"),
-
-        ("gender_raw", "Gender (Value) - csap_demog"),
-        ("gender_time", "Gender (Time) - csap_demog"),
-        ("location_raw", "Mog_Sub_District (Value) - csap_demog"),
-        ("location_time", "Mog_Sub_District (Time) - csap_demog"),
-        ("age_raw", "Age (Value) - csap_demog"),
-        ("age_time", "Age (Time) - csap_demog"),
-        ("idp_camp_raw", "Idp_Camp (Value) - csap_demog"),
-        ("idp_camp_time", "Idp_Camp (Time) - csap_demog"),
-        ("recently_displaced_raw", "Recently_Displaced (Value) - csap_demog"),
-        ("recently_displaced_time", "Recently_Displaced (Time) - csap_demog"),
-        ("household_language_raw", "Hh_Language (Value) - csap_demog"),
-        ("household_language_time", "Hh_Language (Time) - csap_demog"),
-
-        ("gender_raw", "Gender (Value) - csap_s02_demog"),
-        ("gender_time", "Gender (Time) - csap_s02_demog"),
-        ("location_raw", "District (Value) - csap_s02_demog"),
-        ("location_time", "District (Time) - csap_s02_demog"),
-        ("age_raw", "Age (Value) - csap_s02_demog"),
-        ("age_time", "Age (Time) - csap_s02_demog"),
-        ("idp_camp_raw", "Idp_Camp (Value) - csap_s02_demog"),
-        ("idp_camp_time", "Idp_Camp (Time) - csap_s02_demog"),
-        ("recently_displaced_raw", "Recently_Displaced (Value) - csap_s02_demog"),
-        ("recently_displaced_time", "Recently_Displaced (Time) - csap_s02_demog"),
-        ("household_language_raw", "Hh_Language (Value) - csap_s02_demog"),
-        ("household_language_time", "Hh_Language (Time) - csap_s02_demog"),
-
-        # ("repeated_raw", "Repeated (Value) - csap_evaluation"),
-        # ("repeated_time", "Repeated (Time) - csap_evaluation"),
-        # ("involved_raw", "Involved (Value) - csap_evaluation"),
-        # ("involved_time", "Involved (Time) - csap_evaluation")
-    ]
-
     SHOW_ID_MAP = {
         "Rqa_S02E01 (Value) - csap_s02e01_activation": 1,
         "Rqa_S02E02 (Value) - csap_s02e02_activation": 2,
@@ -113,7 +63,7 @@ class TranslateRapidProKeys(object):
         pass
 
     @classmethod
-    def remap_key_names(cls, user, data, key_map):
+    def remap_key_names(cls, user, data, pipeline_configuration):
         """
         Remaps key names.
         
@@ -121,13 +71,16 @@ class TranslateRapidProKeys(object):
         :type user: str
         :param data: TracedData objects to remap the key names of.
         :type data: iterable of TracedData
-        :param key_map: Iterable of (new_key, old_key).
-        :type key_map: iterable of (str, str)
+        :param pipeline_configuration: Pipeline configuration.
+        :type pipeline_configuration: PipelineConfiguration
         """
         for td in data:
             remapped = dict()
                
-            for new_key, old_key in key_map:
+            for remapping in pipeline_configuration.rapid_pro_key_remappings:
+                old_key = remapping.rapid_pro_key
+                new_key = remapping.pipeline_key
+                
                 if old_key in td and new_key not in td:
                     remapped[new_key] = td[old_key]
 
@@ -157,7 +110,7 @@ class TranslateRapidProKeys(object):
                                    Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
     @classmethod
-    def translate_rapid_pro_keys(cls, user, data, coda_input_dir):
+    def translate_rapid_pro_keys(cls, user, data, pipeline_configuration, coda_input_dir):
         """
         Remaps the keys of rqa messages in the wrong flow into the correct one, and remaps all Rapid Pro keys to
         more usable keys that can be used by the rest of the pipeline.
@@ -174,7 +127,7 @@ class TranslateRapidProKeys(object):
         cls.remap_radio_shows(user, data, coda_input_dir)
 
         # Remap the keys used by Rapid Pro to more usable key names that will be used by the rest of the pipeline.
-        cls.remap_key_names(user, data, cls.RAPID_PRO_KEY_MAP)
+        cls.remap_key_names(user, data, pipeline_configuration)
 
         # Convert from the new show id format to the raw field format still used by the rest of the pipeline.
         cls.set_rqa_raw_keys_from_show_ids(user, data, cls.RAW_ID_MAP)


### PR DESCRIPTION
Note that I have extended the existing PipelineConfiguration object to support instance variables (set from the configuration json) making that class a weird hybrid of json-derived instance variables and hard-coded class variables. In future PRs, the remaining class variables will be moved to json.