### PR TITLE
Move TracedData export to go before the Drive upload, not after

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -164,6 +164,10 @@ if __name__ == "__main__":
     with open(json_output_path, "w") as f:
         TracedDataJsonIO.export_traced_data_iterable_to_json(data, f, pretty_print=True)
 
+    # Upload to Google Drive, if requested.
+    # Note: This should happen as late as possible in order to reduce the risk of the remainder of the pipeline failing
+    # after a Drive upload has occurred. Failures could result in inconsistent outputs or outputs with no
+    # traced data log.
     if drive_upload:
         print("Uploading CSVs to Google Drive...")
         drive_client_wrapper.init_client(drive_credentials_path)

--- a/pipeline.py
+++ b/pipeline.py
@@ -186,6 +186,6 @@ if __name__ == "__main__":
                                               target_file_name=production_csv_drive_file_name,
                                               target_folder_is_shared_with_me=True)
     else:
-        print("Not uploading to Google Drive")
+        print("Skipping uploading to Google Drive (because --drive-upload flag was not set)")
 
     print("Python script complete")

--- a/pipeline.py
+++ b/pipeline.py
@@ -159,6 +159,11 @@ if __name__ == "__main__":
     print("Generating Analysis CSVs...")
     data = AnalysisFile.generate(user, data, csv_by_message_output_path, csv_by_individual_output_path)
 
+    print("Writing TracedData to file...")
+    IOUtils.ensure_dirs_exist_for_file(json_output_path)
+    with open(json_output_path, "w") as f:
+        TracedDataJsonIO.export_traced_data_iterable_to_json(data, f, pretty_print=True)
+
     if drive_upload:
         print("Uploading CSVs to Google Drive...")
         drive_client_wrapper.init_client(drive_credentials_path)
@@ -182,10 +187,5 @@ if __name__ == "__main__":
                                               target_folder_is_shared_with_me=True)
     else:
         print("Not uploading to Google Drive")
-
-    print("Writing TracedData to file...")
-    IOUtils.ensure_dirs_exist_for_file(json_output_path)
-    with open(json_output_path, "w") as f:
-        TracedDataJsonIO.export_traced_data_iterable_to_json(data, f, pretty_print=True)
 
     print("Python script complete")


### PR DESCRIPTION
This reduces the risk of the pipeline failing after Drive upload, which decreases the risk of having data for analysis with no associated TracedData file.