### PR TITLE
Move the data root backup code to its own script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Running the pipeline requires
 (1) creating a phone number <-> UUID table to support de-identification of respondents, 
 (2) optionally downloading coded data from Coda, 
 (3) fetching all the relevant data from Rapid Pro, 
-(4) processing the raw data to produce the outputs required for coding and then for analysis, and
-(5) uploading new data to Coda for manual verification and coding.
+(4) processing the raw data to produce the outputs required for coding and then for analysis
+(5) uploading new data to Coda for manual verification and coding, and
+(6) optionally backing-up the project data root.
 
 To simplify the configuration and execution of these stages, this project includes a `run_scripts`
 directory, which contains shell scripts for driving each of those stages. 
@@ -115,6 +116,21 @@ where:
   data_tools directory (which contains the `get.py` script).
 - `data-root` is an absolute path to the directory in which all pipeline data should be stored.
   Downloaded Coda files are saved to `<data-root>/Coded Coda Files/<dataset>.json`.
+
+### 6. Back-up the Data Directory
+This stage makes a backup of the project data directory by creating a compressed, versioned, time-stamped copy at the
+requested location.
+To use, run the following command from the `run_scripts` directory:
+
+```
+$ ./5_backup_data_root.sh <data-root> <data-backups-dir>
+```
+
+where:
+- `data-root` is an absolute path to the directory to back-up.
+- `data-backups-dir` is a directory which the `data-root` directory will be backed-up to.
+  The data is gzipped and given the name `data-<utc-date-time-now>-<git-HEAD-hash>`.
+
 
 ## Development
 

--- a/run_scripts/5_backup_data_root.sh
+++ b/run_scripts/5_backup_data_root.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: ./5_backup_data_root <data-root> <data-backups-dir>"
+    echo "Backs-up the data root directory to a compressed file in a backups directory"
+    echo "The directory is gzipped and given the name 'data-<utc-date-time-now>-<git-HEAD-hash>'"
+    exit
+fi
+
+DATA_ROOT=$1
+DATA_BACKUPS_DIR=$2
+
+DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+HASH=$(git rev-parse HEAD)
+mkdir -p "$DATA_BACKUPS_DIR"
+find "$DATA_ROOT" -type f -name '.DS_Store' -delete
+cd "$DATA_ROOT"
+tar -czvf "$DATA_BACKUPS_DIR/data-$DATE-$HASH.tar.gzip" .

--- a/run_scripts/run_pipeline.sh
+++ b/run_scripts/run_pipeline.sh
@@ -28,10 +28,4 @@ DATA_BACKUPS_DIR=$8
 
 ./4_coda_add.sh "$CODA_PUSH_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
-# Backup the project data directory
-DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-HASH=$(git rev-parse HEAD)
-mkdir -p "$DATA_BACKUPS_DIR"
-find "$DATA_ROOT" -type f -name '.DS_Store' -delete
-cd "$DATA_ROOT"
-tar -czvf "$DATA_BACKUPS_DIR/data-$DATE-$HASH.tar.gzip" .
+./5_backup_data_root.sh "$DATA_ROOT" "$DATA_BACKUPS_DIR"


### PR DESCRIPTION
This (a) makes the location of this code consistent with the rest of the pipeline shell scripts, and (b) means we can back-up the project data root without having to run the rest of the pipeline first, which I'm occasionally finding useful to be able to do.